### PR TITLE
Fix extendWithResolvers

### DIFF
--- a/packages/graphql-api/src/schema-builder.js
+++ b/packages/graphql-api/src/schema-builder.js
@@ -58,10 +58,10 @@ export const createJSAccountsGraphQL = (Accounts: any, schemaOptions: SchemaGene
     extendWithResolvers: resolversObject => ({
       ...resolversObject,
       [schemaOptions.rootMutationName]: Object.assign(
-        resolversObject[schemaOptions.rootMutationName],
+        resolversObject[schemaOptions.rootMutationName] || {},
         resolvers[schemaOptions.rootMutationName]),
       [schemaOptions.rootQueryName]: Object.assign(
-        resolversObject[schemaOptions.rootQueryName],
+        resolversObject[schemaOptions.rootQueryName] || {},
         resolvers[schemaOptions.rootQueryName]),
       User: Object.assign(
         resolversObject.User || {},


### PR DESCRIPTION
if `resolversObject` doenst contain a `Query` or a `Mutation` an error is thrown because `object.assign` will try to assign to `undefined`