### PR TITLE
Bugfix/backward compatibility

### DIFF
--- a/packages/graphql-api/src/graphql/mutations.js
+++ b/packages/graphql-api/src/graphql/mutations.js
@@ -1,5 +1,5 @@
 export const mutations = `
-  loginWithPassword(user: UserInput!, password: String!): LoginReturn
+  loginWithPassword(user: String, userInput: UserInput, password: String!): LoginReturn
   refreshTokens(accessToken: String!, refreshToken: String!): LoginReturn
   logout(accessToken: String!): Boolean
   impersonate(accessToken: String! username: String!): ImpersonateReturn

--- a/packages/graphql-api/src/resolvers/login-with-password.js
+++ b/packages/graphql-api/src/resolvers/login-with-password.js
@@ -1,7 +1,7 @@
 export const loginWithPassword = Accounts =>
   (async (_, { user, userInput, password }) => {
     if (userInput) {
-      return await Accounts.loginWithPassword(user, password);
+      return await Accounts.loginWithPassword(userInput, password);
     } else if (user && typeof user === 'string') {
       return await Accounts.loginWithPassword({ username: user }, password);
     }

--- a/packages/graphql-api/src/resolvers/login-with-password.js
+++ b/packages/graphql-api/src/resolvers/login-with-password.js
@@ -4,7 +4,7 @@ export const loginWithPassword = Accounts =>
       return await Accounts.loginWithPassword(user, password);
     } else if (user && typeof user === 'string') {
       return await Accounts.loginWithPassword({ username: user }, password);
-    } else {
-      throw new Error('Missing user/userInput!');
     }
+
+    throw new Error('Missing user/userInput!');
   });

--- a/packages/graphql-api/src/resolvers/login-with-password.js
+++ b/packages/graphql-api/src/resolvers/login-with-password.js
@@ -4,5 +4,7 @@ export const loginWithPassword = Accounts =>
       return await Accounts.loginWithPassword(user, password);
     } else if (user && typeof user === 'string') {
       return await Accounts.loginWithPassword({ username: user }, password);
+    } else {
+      throw new Error('Missing user/userInput!');
     }
   });

--- a/packages/graphql-api/src/resolvers/login-with-password.js
+++ b/packages/graphql-api/src/resolvers/login-with-password.js
@@ -1,3 +1,8 @@
 export const loginWithPassword = Accounts =>
-  (async (_, { user, password }) =>
-    await Accounts.loginWithPassword(user, password));
+  (async (_, { user, userInput, password }) => {
+    if (userInput) {
+      return await Accounts.loginWithPassword(user, password);
+    } else if (user && typeof user === 'string') {
+      return await Accounts.loginWithPassword({ username: user }, password);
+    }
+  });

--- a/packages/graphql-client/src/graphql-client.js
+++ b/packages/graphql-client/src/graphql-client.js
@@ -67,7 +67,7 @@ export class GraphQLClient {
   // eslint-disable-next-line max-len
   async loginWithPassword(user: PasswordLoginUserIdentityType, password: string): Promise<LoginReturnType> {
     const loginMutation = createLoginMutation(this.options.userFieldsFragment);
-    return await this.mutate(loginMutation, 'loginWithPassword', { user, password });
+    return await this.mutate(loginMutation, 'loginWithPassword', { userInput: user, password });
   }
 
   async impersonate(accessToken: string, username: string): Promise<ImpersonateReturnType> {

--- a/packages/graphql-client/src/graphql/login.mutation.js
+++ b/packages/graphql-client/src/graphql/login.mutation.js
@@ -2,8 +2,8 @@ import gql from 'graphql-tag';
 import { loginFieldsFragment } from './login-fields.fragment';
 
 export const createLoginMutation = userFieldsFragment => gql`
-  mutation($user: UserInput!, $password: String!) {
-    loginWithPassword(user: $user, password: $password) {
+  mutation($user: String, $userInput: UserInput, $password: String!) {
+    loginWithPassword(user: $user, userInput: $userInput, password: $password) {
       sessionId
       ...LoginFields
       user {


### PR DESCRIPTION
- The recent changes by @tomermoshe caused the `user` field of `loginWithPassword` to be of typer `UserInput` instead `String`, causing the previous API to break and prevents users to login when using latest version.

This PR changes `user` argument to type `String` and added another optional input type for `UserInput`. 
