### PR TITLE
Use the right parameter name

### DIFF
--- a/packages/graphql-client/src/graphql/reset-password.mutation.ts
+++ b/packages/graphql-client/src/graphql/reset-password.mutation.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const resetPasswordMutation = gql`
-    mutation($token: String!, $password: PasswordInput!) {
-        resetPassword(token: $token, password: $password)
+    mutation($token: String!, $newPassword: PasswordInput!) {
+        resetPassword(token: $token, newPassword: $password)
     }
 `;


### PR DESCRIPTION
Fixes `resetPassword()` mutation not being invoked properly